### PR TITLE
Death-test fixes

### DIFF
--- a/Demo/Common/Full/death.c
+++ b/Demo/Common/Full/death.c
@@ -181,7 +181,11 @@ unsigned portBASE_TYPE uxTasksRunningNow;
 	{
 		sReturn = pdFALSE;
 	}
-	
+	else
+	{
+		sLastCreationCount = sCreationCount;
+	}
+
 	uxTasksRunningNow = uxTaskGetNumberOfTasks();
 
 	if( uxTasksRunningNow < uxTasksRunningAtStart )

--- a/Demo/Common/Full/death.c
+++ b/Demo/Common/Full/death.c
@@ -77,7 +77,7 @@ static volatile short sCreationCount = 0;
 /* Used to store the number of tasks that were originally running so the creator 
 task can tell if any of the suicidal tasks have failed to die. */
 static volatile unsigned portBASE_TYPE uxTasksRunningAtStart = 0;
-static const unsigned portBASE_TYPE uxMaxNumberOfExtraTasksRunning = 5;
+static const unsigned portBASE_TYPE uxMaxNumberOfExtraTasksRunning = 6;
 
 /* Used to store a handle to the tasks that should be killed by a suicidal task, 
 before it kills itself. */


### PR DESCRIPTION
I'm new to FreeRTOS and naturally started using this simulator. When running the test-application I saw that it didn't work for version 10 but was OK for 9.

Here is a fix for that. Please let me know whether this is indeed fixing something or just hiding a porting problem.

In addition, one check was not completely correct (sLastCreationCount was never set to something else than 0). Fixed as well.